### PR TITLE
196925/ Add domain classes and mysql support

### DIFF
--- a/initial/build.gradle
+++ b/initial/build.gradle
@@ -62,6 +62,7 @@ dependencies {
     profile "org.grails.profiles:web"
     runtime "org.glassfish.web:el-impl:2.1.2-b03"
     runtime "com.h2database:h2"
+    runtime 'mysql:mysql-connector-java:5.1.40'
     runtime "org.apache.tomcat:tomcat-jdbc"
     runtime "javax.xml.bind:jaxb-api:2.3.0"
     runtime "com.bertramlabs.plugins:asset-pipeline-grails:3.0.11"

--- a/initial/gradle.properties
+++ b/initial/gradle.properties
@@ -1,2 +1,4 @@
+#Wed Jan 13 11:59:55 CST 2021
 grailsVersion=4.0.1
 gormVersion=7.0.2.RELEASE
+grailsWrapperVersion=1.0.0

--- a/initial/grails-app/conf/application.yml
+++ b/initial/grails-app/conf/application.yml
@@ -95,15 +95,16 @@ hibernate:
 dataSource:
     pooled: true
     jmxExport: true
-    driverClassName: org.h2.Driver
+    driverClassName: com.mysql.jdbc.Driver
+    dialect: org.hibernate.dialect.MySQL5InnoDBDialect
     username: sa
-    password: ''
+    password: testing
 
 environments:
     development:
         dataSource:
-            dbCreate: create-drop
-            url: jdbc:h2:mem:devDb;MVCC=TRUE;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE
+            dbCreate: update
+            url: jdbc:mysql://127.0.0.1:3306/myapp
     test:
         dataSource:
             dbCreate: update

--- a/initial/grails-app/domain/org/grails/guides/Make.groovy
+++ b/initial/grails-app/domain/org/grails/guides/Make.groovy
@@ -1,0 +1,13 @@
+package org.grails.guides
+
+class Make {
+
+    String name
+
+    static constraints = {
+    }
+
+    String toString() {
+        name
+    }
+}

--- a/initial/grails-app/domain/org/grails/guides/Model.groovy
+++ b/initial/grails-app/domain/org/grails/guides/Model.groovy
@@ -1,0 +1,15 @@
+package org.grails.guides
+
+class Model {
+
+    String name
+
+    static belongsTo = [ make: Make ]
+
+    static constraints = {
+    }
+
+    String toString() {
+        name
+    }
+}

--- a/initial/grails-app/domain/org/grails/guides/Vehicle.groovy
+++ b/initial/grails-app/domain/org/grails/guides/Vehicle.groovy
@@ -1,0 +1,16 @@
+package org.grails.guides
+
+@SuppressWarnings('GrailsDomainReservedSqlKeywordName')
+class Vehicle {
+
+    Integer year
+
+    String name
+    Model model
+    Make make
+
+    static constraints = {
+        year min: 1900
+        name maxSize: 255
+    }
+}

--- a/initial/grails-app/init/org/grails/guides/BootStrap.groovy
+++ b/initial/grails-app/init/org/grails/guides/BootStrap.groovy
@@ -1,8 +1,25 @@
 package org.grails.guides
 
+import groovy.transform.CompileStatic
+
+@CompileStatic
 class BootStrap {
 
+    MakeService makeService
+    ModelService modelService
+    VehicleService vehicleService
     def init = { servletContext ->
+
+        Make nissan = makeService.save('Nissan')
+        Make ford = makeService.save( 'Ford')
+
+        Model titan = modelService.save('Titan', nissan)
+        Model leaf = modelService.save('Leaf', nissan)
+        Model windstar = modelService.save('Windstar', ford)
+
+        vehicleService.save('Pickup', nissan, titan, 2012).save()
+        vehicleService.save('Economy', nissan, leaf, 2014).save()
+        vehicleService.save('Minivan', ford, windstar, 1990).save()
     }
     def destroy = {
     }

--- a/initial/grails-app/services/org/grails/guides/MakeService.groovy
+++ b/initial/grails-app/services/org/grails/guides/MakeService.groovy
@@ -1,0 +1,8 @@
+package org.grails.guides
+
+import grails.gorm.services.Service
+
+@Service(Make)
+interface MakeService {
+    Make save(String name)
+}

--- a/initial/grails-app/services/org/grails/guides/ModelService.groovy
+++ b/initial/grails-app/services/org/grails/guides/ModelService.groovy
@@ -1,0 +1,8 @@
+package org.grails.guides
+
+import grails.gorm.services.Service
+
+@Service(Model)
+interface ModelService {
+    Model save(String name, Make make)
+}

--- a/initial/grails-app/services/org/grails/guides/VehicleService.groovy
+++ b/initial/grails-app/services/org/grails/guides/VehicleService.groovy
@@ -1,0 +1,8 @@
+package org.grails.guides
+
+import grails.gorm.services.Service
+
+@Service(Vehicle)
+interface VehicleService {
+    Vehicle save(String name, Make make, Model model, Integer year)
+}

--- a/initial/src/test/groovy/org/grails/guides/MakeServiceSpec.groovy
+++ b/initial/src/test/groovy/org/grails/guides/MakeServiceSpec.groovy
@@ -1,0 +1,18 @@
+package org.grails.guides
+
+import grails.testing.services.ServiceUnitTest
+import spock.lang.Specification
+
+class MakeServiceSpec extends Specification implements ServiceUnitTest<MakeService>{
+
+    def setup() {
+    }
+
+    def cleanup() {
+    }
+
+    void "test something"() {
+        expect:"fix me"
+            true == false
+    }
+}

--- a/initial/src/test/groovy/org/grails/guides/MakeSpec.groovy
+++ b/initial/src/test/groovy/org/grails/guides/MakeSpec.groovy
@@ -1,0 +1,18 @@
+package org.grails.guides
+
+import grails.testing.gorm.DomainUnitTest
+import spock.lang.Specification
+
+class MakeSpec extends Specification implements DomainUnitTest<Make> {
+
+    def setup() {
+    }
+
+    def cleanup() {
+    }
+
+    void "test something"() {
+        expect:"fix me"
+            true == false
+    }
+}

--- a/initial/src/test/groovy/org/grails/guides/ModelServiceSpec.groovy
+++ b/initial/src/test/groovy/org/grails/guides/ModelServiceSpec.groovy
@@ -1,0 +1,18 @@
+package org.grails.guides
+
+import grails.testing.services.ServiceUnitTest
+import spock.lang.Specification
+
+class ModelServiceSpec extends Specification implements ServiceUnitTest<ModelService>{
+
+    def setup() {
+    }
+
+    def cleanup() {
+    }
+
+    void "test something"() {
+        expect:"fix me"
+            true == false
+    }
+}

--- a/initial/src/test/groovy/org/grails/guides/ModelSpec.groovy
+++ b/initial/src/test/groovy/org/grails/guides/ModelSpec.groovy
@@ -1,0 +1,18 @@
+package org.grails.guides
+
+import grails.testing.gorm.DomainUnitTest
+import spock.lang.Specification
+
+class ModelSpec extends Specification implements DomainUnitTest<Model> {
+
+    def setup() {
+    }
+
+    def cleanup() {
+    }
+
+    void "test something"() {
+        expect:"fix me"
+            true == false
+    }
+}

--- a/initial/src/test/groovy/org/grails/guides/VehicleServiceSpec.groovy
+++ b/initial/src/test/groovy/org/grails/guides/VehicleServiceSpec.groovy
@@ -1,0 +1,18 @@
+package org.grails.guides
+
+import grails.testing.services.ServiceUnitTest
+import spock.lang.Specification
+
+class VehicleServiceSpec extends Specification implements ServiceUnitTest<VehicleService>{
+
+    def setup() {
+    }
+
+    def cleanup() {
+    }
+
+    void "test something"() {
+        expect:"fix me"
+            true == false
+    }
+}

--- a/initial/src/test/groovy/org/grails/guides/VehicleSpec.groovy
+++ b/initial/src/test/groovy/org/grails/guides/VehicleSpec.groovy
@@ -1,0 +1,18 @@
+package org.grails.guides
+
+import grails.testing.gorm.DomainUnitTest
+import spock.lang.Specification
+
+class VehicleSpec extends Specification implements DomainUnitTest<Vehicle> {
+
+    def setup() {
+    }
+
+    def cleanup() {
+    }
+
+    void "test something"() {
+        expect:"fix me"
+            true == false
+    }
+}


### PR DESCRIPTION
# Related tasks
+ [Crear aplicación de ejemplo grails](https://manoderecha.net/md/index.php/task/196925)

# Problem description
[5 Domain Classes](https://guides.grails.org/creating-your-first-grails-app/guide/index.html) 
+ Creating a Domain Class
+ Bootstrapping Data
+ Configure MySQL Datasource  

# Solution description
+ Create domain classes
+ Update BootStrap file
+ Change the datasource in `initial/grails-app/conf/application.yml`

# Test changes
+ Open in the browser: `http://localhost:8080/`
+ Validate the initial data in mysql

# Testing
+ [X] Ran automated tests
+ [ ] Ran codenarc

# Evidence
![Captura de pantalla de 2021-01-13 13-39-57](https://user-images.githubusercontent.com/8205953/104503935-5b06be00-55a7-11eb-9c85-0c6ae16fed1d.png)
 

# Database changes
+ Add vehicle
+ Add model
+ Add make

# Endpoint changes
+ None
